### PR TITLE
Update dependencies in net-mail/offlineimap3

### DIFF
--- a/net-mail/offlineimap3/offlineimap3-9999.ebuild
+++ b/net-mail/offlineimap3/offlineimap3-9999.ebuild
@@ -1,9 +1,9 @@
 # Copyright 2021-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 PYTHON_REQ_USE="sqlite,ssl?"
 DISTUTILS_USE_PEP517=setuptools
 
@@ -17,16 +17,18 @@ LICENSE="GPL-2+"
 SLOT="0"
 IUSE="doc kerberos ssl"
 
-DEPEND="doc? ( app-text/asciidoc )"
-RDEPEND="
+DEPEND="
 	dev-python/certifi[${PYTHON_USEDEP}]
 	dev-python/distro[${PYTHON_USEDEP}]
 	>=dev-python/imaplib2-2.57[${PYTHON_USEDEP}]
+	dev-python/keyring[${PYTHON_USEDEP}]
 	dev-python/pyyaml[${PYTHON_USEDEP}]
 	dev-python/rfc6555[${PYTHON_USEDEP}]
 	>=dev-python/urllib3-1.25.9[${PYTHON_USEDEP}]
+	doc? ( app-text/asciidoc )
 	kerberos? ( dev-python/gssapi[${PYTHON_USEDEP}] )
 "
+RDEPEND="${DEPEND}"
 BDEPEND="
 	test? ( dev-python/pytest-cov[${PYTHON_USEDEP}] )
 "


### PR DESCRIPTION
The OfflineImap repo had [a PR merged recently](https://github.com/OfflineIMAP/offlineimap3/pull/102), to add support for keyring. This leads to a missing dependency when using your Ebuild.

I've added the missing dependency and also updated and restructured the dependeny handling in general. The original ebuild wasn't working when being used in [a `ROOT` variable environment](https://devmanual.gentoo.org/ebuild-writing/variables/index.html#root). The dependencies are not simply RDEPEND as they need to be present in the host system during install.