### PR TITLE
Update clipmenu live ebuild

### DIFF
--- a/x11-misc/clipmenu/clipmenu-9999.ebuild
+++ b/x11-misc/clipmenu/clipmenu-9999.ebuild
@@ -12,8 +12,9 @@ EGIT_BRANCH="develop"
 
 LICENSE="MIT"
 SLOT="0"
-IUSE="+dmenu fzf rofi"
+IUSE="+dmenu fzf rofi test"
 REQUIRED_USE="?? ( dmenu fzf rofi )"
+RESTRICT="!test? ( test )"
 
 DEPEND="
 	x11-libs/libX11
@@ -39,6 +40,7 @@ src_prepare() {
 
 src_compile() {
 	emake CFLAGS="${CFLAGS}"
+	use test && emake CFLAGS="${CFLAGS}" tests/test_store
 }
 
 src_install() {
@@ -46,6 +48,12 @@ src_install() {
 		systemd_user_dir="${D}/$(systemd_get_userunitdir)"
 
 	einstalldocs
+}
+
+src_test() {
+	# NOTE(NRK): the "x_integration_tests" are not enabled as they would
+	# require additional setup and dependencies
+	emake tests
 }
 
 pkg_postinst() {

--- a/x11-misc/clipmenu/clipmenu-9999.ebuild
+++ b/x11-misc/clipmenu/clipmenu-9999.ebuild
@@ -42,7 +42,8 @@ src_compile() {
 }
 
 src_install() {
-	emake DESTDIR="${D}" PREFIX="${EPREFIX}"/usr install
+	emake install DESTDIR="${D}" PREFIX="${EPREFIX}"/usr \
+		systemd_user_dir="${D}/$(systemd_get_userunitdir)"
 
 	einstalldocs
 }


### PR DESCRIPTION
### x11-misc/clipmenu: use systemd_get_userunitdir

the systemd.eclass uses systemd pkg-config file to determine the
location. might be more robust/correct this way.

### x11-misc/clipmenu: enable tests

but not x_integration_tests tests as they are more convoluted.
