### PR TITLE
app-misc/clight: restore version string patch

### DIFF
--- a/app-misc/clight/files/clight-version.patch
+++ b/app-misc/clight/files/clight-version.patch
@@ -1,0 +1,32 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 39347ec..7cddd95 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -14,11 +14,17 @@ set(CLIGHT_DATADIR "${CMAKE_INSTALL_FULL_DATADIR}/clight"
+     CACHE PATH "Path for data dir folder")
+ 
+ execute_process(
+-        COMMAND git log -1 --format=%h
++        COMMAND sh -c "test -d .git && git log -1 --format=%h"
+         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+         OUTPUT_VARIABLE GIT_HASH
+         OUTPUT_STRIP_TRAILING_WHITESPACE
+ )
++
++if(GIT_HASH)
++    set(VERSION "${PROJECT_VERSION}-${GIT_HASH}")
++else()
++    set(VERSION "${PROJECT_VERSION}")
++endif()
+     
+ # Create program target
+ file(GLOB_RECURSE SOURCES src/*.c)
+@@ -33,7 +39,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE
+ )
+ target_compile_definitions(${PROJECT_NAME} PRIVATE
+     -D_GNU_SOURCE
+-    -DVERSION="${PROJECT_VERSION}-${GIT_HASH}"
++    -DVERSION="${VERSION}"
+     -DCONFDIR="${CLIGHT_CONFDIR}"
+     -DOLDCONFDIR="${CMAKE_INSTALL_FULL_SYSCONFDIR}/default"
+     -DDATADIR="${CLIGHT_DATADIR}"


### PR DESCRIPTION
This PR aims to fix #7 by restoring the patch still required by app-misc/clight-4.11.

This partially reverts commit 570469223123b79f28b59ef7801fd88cf6f1476b.